### PR TITLE
Fix flash message background showing after dismiss

### DIFF
--- a/taskui/static/index.css
+++ b/taskui/static/index.css
@@ -35,7 +35,6 @@ td.empty-table-message {
 .flash-container {
   display: flex;
   color: #fff;
-  padding: 4px;
 }
 
 /* message is the default category in Flask */
@@ -58,12 +57,12 @@ td.empty-table-message {
 .flash-message-body {
   display: inline-block;
   flex-grow: 1;
-  padding: 8px;
+  padding: 12px;
 }
 
 .flash-dismiss {
   display: inline-block;
-  padding: 8px;
+  padding: 12px;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
Due to the padding on the container, when hiding the contents you saw a
small 8px line where the banner was.

Fixes #5 