### PR TITLE
Fix mobile-friendly - wrap tables in overflow div

### DIFF
--- a/taskui/static/index.css
+++ b/taskui/static/index.css
@@ -6,13 +6,16 @@ body {
   margin: 16px 10%;
 }
 
+.tablewrapper {
+  display: block;
+  overflow-x: auto;
+}
+
 table {
 	border: double grey;
   border-collapse: collapse;
   margin: 16px 0px;
   width: 100%;
-  display: block;
-  overflow-x: auto;
 }
 
 td, th {

--- a/taskui/templates/completed.html.jinja
+++ b/taskui/templates/completed.html.jinja
@@ -20,35 +20,37 @@
         {% endfor %}
       {% endif %}
     {% endwith %}
-    <table>
-      <thead>
-        <tr>
-          <th> # </th> 
-          <th> Requested </th> 
-          <th> Completed </th>
-          <th> Type </th>
-          <th> User </th> 
-          <th class='wide'> Request </th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for task in tasks %}
-        <tr>
-          <td> {{ loop.index }} </td>
-          <td> {{ task.date }} </td>
-          <td> {{ task.completed_date }} </td>
-          <td> {{ task.type }} </td>
-          <td> {{ task.user }} </td>
-          <td> {{ task.body }} </td>
-        </tr>
-        {% endfor %}
-        {% if tasks|length == 0 %}
-        <tr>
-          <td colspan="6" class='empty-table-message' > No {{ title | lower }} tasks :( </td>
-        </tr>
-        {% endif %}
-      </tbody>
-    </table>
+    <div class='tablewrapper'>
+      <table>
+        <thead>
+          <tr>
+            <th> # </th>
+            <th> Requested </th>
+            <th> Completed </th>
+            <th> Type </th>
+            <th> User </th>
+            <th class='wide'> Request </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for task in tasks %}
+          <tr>
+            <td> {{ loop.index }} </td>
+            <td> {{ task.date }} </td>
+            <td> {{ task.completed_date }} </td>
+            <td> {{ task.type }} </td>
+            <td> {{ task.user }} </td>
+            <td> {{ task.body }} </td>
+          </tr>
+          {% endfor %}
+          {% if tasks|length == 0 %}
+          <tr>
+            <td colspan="6" class='empty-table-message' > No {{ title | lower }} tasks :( </td>
+          </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
     <details>
       <summary> Stats </summary>
       <ul>
@@ -57,7 +59,7 @@
         {% endfor %}
       </ul>
     </details>
-    <footer>    
+    <footer>
       <nav>
         <a href="{{ url_for('open') }}">All Open</a> |
         {% for type in types%}

--- a/taskui/templates/open.html.jinja
+++ b/taskui/templates/open.html.jinja
@@ -21,35 +21,37 @@
       {% endif %}
     {% endwith %}
     <form action='/action/complete' name='open' method="post">
-      <table>
-        <thead>
+      <div class='tablewrapper'>
+        <table>
+          <thead>
+            <tr>
+              <th> # </th>
+              <th> Date </th>
+              {% if not by_type %}  <th> Type </th> {% endif %}
+              <th> User </th>
+              <th class='wide'> Request </th>
+              <th class='action'> Complete </th>
+            </tr>
+          </thead>
+          <tbody>
+          {% for task in tasks %}
           <tr>
-            <th> # </th> 
-            <th> Date </th> 
-            {% if not by_type %}  <th> Type </th> {% endif %}
-            <th> User </th> 
-            <th class='wide'> Request </th>
-            <th class='action'> Complete </th>
+            <td> {{ loop.index }} </td>
+            <td> {{ task.date }} </td>
+            {% if not by_type %}<td> {{ task.type }} </td>{% endif %}
+            <td> {{ task.user }} </td>
+            <td> {{ task.body }} </td>
+            <td class='action'> <input autocomplete='off' type='checkbox' name="completedTasks" value="{{ task.id }}" />
           </tr>
-        </thead>
-        <tbody>
-        {% for task in tasks %}
-        <tr>
-          <td> {{ loop.index }} </td>
-          <td> {{ task.date }} </td>
-          {% if not by_type %}<td> {{ task.type }} </td>{% endif %}
-          <td> {{ task.user }} </td>
-          <td> {{ task.body }} </td>
-          <td class='action'> <input autocomplete='off' type='checkbox' name="completedTasks" value="{{ task.id }}" />
-        </tr>
-        {% endfor %}
-        {% if tasks|length == 0 %}
-        <tr>
-          <td colspan="6" class='empty-table-message' > No {{ title | lower }} tasks! </td>
-        </tr>
-        {% endif %}
-        </tbody>
-      </table>
+          {% endfor %}
+          {% if tasks|length == 0 %}
+          <tr>
+            <td colspan="6" class='empty-table-message' > No {{ title | lower }} tasks! </td>
+          </tr>
+          {% endif %}
+          </tbody>
+        </table>
+      </div>
       <div class='submit-container'>
         <input type='submit' id='submit' value='Submit Complete Tasks' {% if tasks|length == 0 %} disabled {% endif %} />
         <p>
@@ -57,7 +59,7 @@
         </p>
       </div>
     </form>
-    <footer>    
+    <footer>
       <nav>
         {% if by_type %}
         <a href="{{ url_for('open') }}">All Open</a> |


### PR DESCRIPTION
By using a wrapper div we can prevent the table rendering from
misbehaving and still get the overflow benefits.